### PR TITLE
Use set_output_multiple() to tell gnuradio scheduler we want multiple…

### DIFF
--- a/lib/fft_impl.h
+++ b/lib/fft_impl.h
@@ -29,6 +29,7 @@ class fft_impl : public fft {
   static constexpr auto kBlockName = "fft";
   size_t samples_per_buffer_;
   size_t buffer_size_;
+  size_t batch_size_;
   CUcontext context_;
   cudaStream_t stream_;
   cufftComplex* fft_data_;


### PR DESCRIPTION
…s of batch size.

This avoids the need to have blocks before and after FFT batch and unbatch (with accompanying memcpy()s).